### PR TITLE
Fix RSS Links

### DIFF
--- a/server/src/http_server/templates/posts.rs
+++ b/server/src/http_server/templates/posts.rs
@@ -1,7 +1,7 @@
 use maud::{html, Markup, Render};
 
 use crate::posts::{
-    blog::{BlogPost, ToCanonicalPath},
+    blog::{BlogPost, LinkTo, ToCanonicalPath},
     til::TilPost,
 };
 
@@ -13,7 +13,7 @@ impl<'a> Render for TilPostList<'a> {
           ul {
             @for post in &self.0 {
               li class="my-4" {
-                a href=(format!("/til/{}", post.frontmatter.slug)) {
+                a href=(post.link()) {
                     span class="text-subtitle text-sm inline-block w-[80px]" { (post.frontmatter.date) }
                     " "
 

--- a/server/src/http_server/templates/posts.rs
+++ b/server/src/http_server/templates/posts.rs
@@ -34,7 +34,7 @@ impl<'a> Render for BlogPostList<'a> {
           ul {
             @for post in &self.0 {
                 li class="my-4" {
-                  a href=(format!("/posts/{}", post.canonical_path())) {
+                  a href=(post.link()) {
                       span class="text-subtitle text-sm inline-block w-[80px]" { (post.date()) }
                       " "
 

--- a/server/src/posts/blog.rs
+++ b/server/src/posts/blog.rs
@@ -10,11 +10,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     http_server::pages::blog::md::IntoHtml,
-    posts::{MarkdownAst, Post}, AppState,
+    posts::{MarkdownAst, Post},
+    AppState,
 };
 
 use super::{
     date::{ByRecency, PostedOn},
+    til::TilPost,
     title::Title,
 };
 
@@ -267,6 +269,22 @@ impl ToCanonicalPath for PathBuf {
         }
 
         format!("{}", self.to_string_lossy())
+    }
+}
+
+pub(crate) trait LinkTo {
+    fn link(&self) -> String;
+}
+
+impl LinkTo for BlogPost {
+    fn link(&self) -> String {
+        format!("posts/{}", self.canonical_path())
+    }
+}
+
+impl LinkTo for TilPost {
+    fn link(&self) -> String {
+        format!("/til/{}", self.frontmatter.slug)
     }
 }
 

--- a/server/src/posts/mod.rs
+++ b/server/src/posts/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 use self::{
-    blog::{PostMarkdown, ToCanonicalPath},
+    blog::{LinkTo, PostMarkdown, ToCanonicalPath},
     date::PostedOn,
     title::Title,
 };
@@ -99,9 +99,10 @@ pub(crate) trait ToRssItem {
 impl<FrontMatter> ToRssItem for Post<FrontMatter>
 where
     FrontMatter: PostedOn + Title,
+    Post<FrontMatter>: LinkTo,
 {
     fn to_rss_item(&self, state: &AppState) -> rss::Item {
-        let link = state.app.app_url(&self.canonical_path());
+        let link = state.app.app_url(&self.link());
 
         let posted_on: DateTime<Utc> = self.posted_on().and_time(NaiveTime::MIN).and_utc();
         let formatted_date = posted_on.to_rfc2822();


### PR DESCRIPTION
I forgot that the links from the RSS were wrong before I deployed it

The blog posts paths still work since we go a redirect for the old blog post style, but I'd rather the links be 'correct'

Also the TILs were just very wrong when done with the canonical path method I was using