### PR TITLE
typo: replace "changed" with "saved" in vscode autosaves article

### DIFF
--- a/til/2023-09-08T18:15:48Z.md
+++ b/til/2023-09-08T18:15:48Z.md
@@ -15,7 +15,7 @@ that after 300ms my code would auto-save. However, auto-formatting would only ru
 not auto-saves triggered by `afterDelay`.
 
 The fix was pretty simple! I switched from `afterDelay` to `onFocusChange`!
-Now my files get changed anytime I switch to a different window or file, and even better auto-formatting
+Now my files get saved anytime I switch to a different window or file, and even better auto-formatting
 runs as well!
 
 Here is a snippet from my new config with a comment I left for future me:


### PR DESCRIPTION
i think this is a typo, feel free to close if not :)