### PR TITLE
Automatic Review Apps

### DIFF
--- a/.github/workflows/fly_review.yml
+++ b/.github/workflows/fly_review.yml
@@ -50,3 +50,9 @@ jobs:
         with:
           name: coreyja-com-pr-${{ github.event.number }}
           secrets: APP_BASE_URL="https://coreyja.com" DATABASE_URL="${{ steps.create-branch.outputs.db_url }}?sslmode=require" TWITCH_CLIENT_ID="FAKE" TWITCH_CLIENT_SECRET="FAKE" TWITCH_BOT_ACCESS_TOKEN="FAKE" TWITCH_BOT_USER_ID="FAKE" TWITCH_CHANNEL_USER_ID="FAKE" GITHUB_APP_ID="123" GITHUB_APP_CLIENT_ID="FAKE" GITHUB_APP_CLIENT_SECRET="FAKE" GITHUB_APP_PRIVATE_KEY="FAKE" GITHUB_PERSONAL_ACCESS_TOKEN="FAKE" OPEN_AI_API_KEY="FAKE" GOOGLE_CLIENT_ID="FAKE" GOOGLE_CLIENT_SECRET="FAKE" ENCRYPTION_SECRET_KEY="FAKE"
+
+      - name: Install Fly CLI
+        run: curl -L https://fly.io/install.sh | FLYCTL_INSTALL=/usr/local sh
+
+      - name: Set APP_BASE_URL
+        run: flyctl secrets set APP_BASE_URL=${{ steps.deploy.outputs.url }} -a coreyja-com-pr-${{ github.event.number }}

--- a/.github/workflows/fly_review.yml
+++ b/.github/workflows/fly_review.yml
@@ -51,8 +51,7 @@ jobs:
           name: coreyja-com-pr-${{ github.event.number }}
           secrets: APP_BASE_URL="https://coreyja.com" DATABASE_URL="${{ steps.create-branch.outputs.db_url }}?sslmode=require" TWITCH_CLIENT_ID="FAKE" TWITCH_CLIENT_SECRET="FAKE" TWITCH_BOT_ACCESS_TOKEN="FAKE" TWITCH_BOT_USER_ID="FAKE" TWITCH_CHANNEL_USER_ID="FAKE" GITHUB_APP_ID="123" GITHUB_APP_CLIENT_ID="FAKE" GITHUB_APP_CLIENT_SECRET="FAKE" GITHUB_APP_PRIVATE_KEY="FAKE" GITHUB_PERSONAL_ACCESS_TOKEN="FAKE" OPEN_AI_API_KEY="FAKE" GOOGLE_CLIENT_ID="FAKE" GOOGLE_CLIENT_SECRET="FAKE" ENCRYPTION_SECRET_KEY="FAKE"
 
-      - name: Install Fly CLI
-        run: curl -L https://fly.io/install.sh | FLYCTL_INSTALL=/usr/local sh
+      - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Set APP_BASE_URL
         run: flyctl secrets set APP_BASE_URL=${{ steps.deploy.outputs.url }} -a coreyja-com-pr-${{ github.event.number }}

--- a/.github/workflows/fly_review.yml
+++ b/.github/workflows/fly_review.yml
@@ -1,0 +1,52 @@
+name: Deploy Review App
+on:
+  # Run this workflow on every PR event. Existing review apps will be updated when the PR is updated.
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+env:
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+  # Set these to your Fly.io organization and preferred region.
+  FLY_REGION: ewr
+  FLY_ORG: personal
+
+jobs:
+  review_app:
+    runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.deploy.outputs.url }}
+    # Only run one deployment at a time per PR.
+    concurrency:
+      group: pr-${{ github.event.number }}
+
+    # Deploying apps with this "review" environment allows the URL for the app to be displayed in the PR UI.
+    # Feel free to change the name of this environment.
+    environment:
+      name: review
+      # The script in the `deploy` sets the URL output for each review app.
+      url: ${{ steps.deploy.outputs.url }}
+
+    steps:
+      - name: Get code
+        uses: actions/checkout@v4
+
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v8
+
+      - name: Create Neon Branch
+        id: create-branch
+        uses: neondatabase/create-branch-action@v4
+        with:
+          project_id: ${{ secrets.NEON_PROJECT_ID }}
+          database: coreyja
+          branch_name: preview/pr-${{ github.event.number }}-${{ steps.branch-name.outputs.current_branch }}
+          username: coreyja
+          api_key: ${{ secrets.NEON_API_KEY }}
+
+      - name: Deploy PR app to Fly.io
+        id: deploy
+        uses: superfly/fly-pr-review-apps@1.2.1
+        with:
+          name: coreyja-com-pr-${{ github.event.number }}
+          secrets: APP_BASE_URL="https://coreyja.com" DATABASE_URL="${{ steps.create-branch.outputs.db_url }}?sslmode=require" TWITCH_CLIENT_ID="FAKE" TWITCH_CLIENT_SECRET="FAKE" TWITCH_BOT_ACCESS_TOKEN="FAKE" TWITCH_BOT_USER_ID="FAKE" TWITCH_CHANNEL_USER_ID="FAKE" GITHUB_APP_ID="123" GITHUB_APP_CLIENT_ID="FAKE" GITHUB_APP_CLIENT_SECRET="FAKE" GITHUB_APP_PRIVATE_KEY="FAKE" GITHUB_PERSONAL_ACCESS_TOKEN="FAKE" OPEN_AI_API_KEY="FAKE" GOOGLE_CLIENT_ID="FAKE" GOOGLE_CLIENT_SECRET="FAKE" ENCRYPTION_SECRET_KEY="FAKE"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/downlo
 
 COPY --from=planner /app/recipe.json recipe.json
 # Build dependencies - this is the caching Docker layer!
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --release --bin server --recipe-path recipe.json
 COPY . .
 
 COPY tailwind.config.js .


### PR DESCRIPTION
Each PR now gets it's own deployment in Fly!

We also use neon PG branches to make an 'isolated' DB based off the main DB. Need to be a bit careful with this to not leak DB stuff to anyone who contributes here. But for now I think its fine

One interesting thing was that I had set the DB_USERNAME via a GithubAction secret, but the username I was using was `coreyja`, which also appeared in the URL output (because of course it did lol)
This forced the URL to be masked and not set as the deployment URL

Had to remove the secret that was set to `coreyja` and hardcode that string in the action to get around that