### PR TITLE
Change cookd Webhook Response Shape

### DIFF
--- a/.sqlx/query-dcc086875437f897e45115b9c5ee8276d983f6bc6cb55d76602ef30f7171fd3a.json
+++ b/.sqlx/query-dcc086875437f897e45115b9c5ee8276d983f6bc6cb55d76602ef30f7171fd3a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        INSERT INTO CookdWebhooks (subdomain, slug, player_github_email, player_github_username, score, created_at, updated_at)\n        VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING cookd_webhook_id\n        ",
+  "query": "\n        INSERT INTO CookdWebhooks (subdomain, slug, player_github_username, score, created_at, updated_at)\n        VALUES ($1, $2, $3, $4, $5, $6) RETURNING cookd_webhook_id\n        ",
   "describe": {
     "columns": [
       {
@@ -14,7 +14,6 @@
         "Text",
         "Text",
         "Text",
-        "Text",
         "Int4",
         "Timestamptz",
         "Timestamptz"
@@ -24,5 +23,5 @@
       false
     ]
   },
-  "hash": "106e44763f2a722953ecdbb9b91337200cee10145588bcb68d47fde4bbd0d592"
+  "hash": "dcc086875437f897e45115b9c5ee8276d983f6bc6cb55d76602ef30f7171fd3a"
 }

--- a/server/src/http_server/webhooks/cookd.rs
+++ b/server/src/http_server/webhooks/cookd.rs
@@ -12,8 +12,7 @@ use crate::{
 struct Payload {
     subdomain: String,
     slug: String,
-    player_github_email: Option<String>,
-    player_github_username: Option<String>,
+    player_response: Option<String>,
     score: i32,
 }
 
@@ -30,13 +29,12 @@ pub(crate) async fn handler(
 
     let db_result = sqlx::query!(
         r#"
-        INSERT INTO CookdWebhooks (subdomain, slug, player_github_email, player_github_username, score, created_at, updated_at)
-        VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING cookd_webhook_id
+        INSERT INTO CookdWebhooks (subdomain, slug, player_github_username, score, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6) RETURNING cookd_webhook_id
         "#,
         payload.subdomain,
         payload.slug,
-        payload.player_github_email,
-        payload.player_github_username,
+        payload.player_response,
         payload.score,
         now,
         now


### PR DESCRIPTION
Change the webhook to include `player_response` instead of `player_github_email` and `player_github_username`.

We will set the custom prompt in the UI to ask for a Github Username
and then just stamp it into the username column I already have!

Since we don't have auth enabled gonna just ignore the other fields for now.