### PR TITLE
fix: correct misspelling of "leaderboard"

### DIFF
--- a/server/src/http_server/pages/bytes.rs
+++ b/server/src/http_server/pages/bytes.rs
@@ -146,7 +146,7 @@ pub(crate) async fn byte_get(Path(slug): Path<String>) -> Result<impl IntoRespon
 
           p class="mb-4" { (byte.short_description) }
 
-          a class="text-xl mb-4 block underline" href=(format!("/bytes/{slug}/leaderboard")) { "View Leadboard" }
+          a class="text-xl mb-4 block underline" href=(format!("/bytes/{slug}/leaderboard")) { "View Leaderboard" }
 
           iframe class="w-full min-h-screen" src=(byte.cookd_url()) {}
         },

--- a/til/2024-08-21T09:46:32Z.md
+++ b/til/2024-08-21T09:46:32Z.md
@@ -7,7 +7,7 @@ slug: github-avatars
 tldr: You can use avatars from Github by adding `.png` to the end of a profile url. For instance this will show you my Github Avatar: `https://github.com/coreyja.png`
 
 On stream on Sunday I was working on adding a Leaderboard for some coding 'games' that I'm going to be adding to the site soon!
-It's all based on Github usernames, and thats what I am displaying on the Leadboard. And I wanted to also include a Users github avatar!
+It's all based on Github usernames, and thats what I am displaying on the Leaderboard. And I wanted to also include a Users github avatar!
 
 I had assumed I was going to need to hit the API to get an avatar for the user, and probably cache that somewhere on my side to avoid needing to make an API call for each page view.
 


### PR DESCRIPTION
noticed this on the bytes page, and then found the other one while searching for the source :)