### PR TITLE
Add admin page for CronRecords management with auto-refresh

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,8 @@
       "Bash(cargo check:*)",
       "mcp__Linear__list_issue_statuses",
       "Bash(cargo clippy:*)",
-      "Bash(jj status:*)"
+      "Bash(jj status:*)",
+      "Bash(find:*)"
     ],
     "deny": []
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,9 @@
       "mcp__Linear__list_issue_statuses",
       "Bash(cargo clippy:*)",
       "Bash(jj status:*)",
-      "Bash(find:*)"
+      "Bash(find:*)",
+      "Bash(jj describe:*)",
+      "Bash(jj new:*)"
     ],
     "deny": []
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,10 +6,14 @@
       "Bash(cargo check:*)",
       "mcp__Linear__list_issue_statuses",
       "Bash(cargo clippy:*)",
+      "Bash(cargo check:*)",
+      "Bash(cargo build:*)",
+      "Bash(cargo fmt:*)",
       "Bash(jj status:*)",
       "Bash(find:*)",
       "Bash(jj describe:*)",
-      "Bash(jj new:*)"
+      "Bash(jj new:*)",
+      "Bash(gh pr view:*)"
     ],
     "deny": []
   }

--- a/.sqlx/query-811f09cf82fea8ef8d8944f102127e6cae8e8e910ba0c1687c5f862c94a44758.json
+++ b/.sqlx/query-811f09cf82fea8ef8d8944f102127e6cae8e8e910ba0c1687c5f862c94a44758.json
@@ -1,0 +1,44 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT cron_id, name, last_run_at, created_at, updated_at FROM Crons ORDER BY name",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "cron_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "last_run_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "811f09cf82fea8ef8d8944f102127e6cae8e8e910ba0c1687c5f862c94a44758"
+}

--- a/.sqlx/query-e45ebd4a51e63e57fbb0f43330cbf3eba29b962ac90c2cfd2d2e00b12dfdd67e.json
+++ b/.sqlx/query-e45ebd4a51e63e57fbb0f43330cbf3eba29b962ac90c2cfd2d2e00b12dfdd67e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE Crons SET last_run_at = $1, updated_at = NOW() WHERE cron_id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e45ebd4a51e63e57fbb0f43330cbf3eba29b962ac90c2cfd2d2e00b12dfdd67e"
+}

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-server: cd server && PORT=3002 cargo watch -x run --no-gitignore
+server: cd server && PORT=3000 cargo watch -x run --no-gitignore
 tailwind: tailwindcss -i server/src/styles/tailwind.css -o target/tailwind.css --watch

--- a/server/src/http_server/admin/crons.rs
+++ b/server/src/http_server/admin/crons.rs
@@ -26,12 +26,22 @@ pub(crate) async fn list_crons(
 
     Ok(base_constrained(
         html! {
-            h1 class="text-xl mb-4" { "Cron Management" }
+            div class="flex items-center justify-between mb-4" {
+                h1 class="text-xl" { "Cron Management" }
+                div class="flex flex-col items-center" {
+                    button id="refresh-button" class="text-gray-600 hover:text-gray-800 transition-colors" title="Refreshes every 10 seconds. Next refresh in 10 seconds. Click to refresh now." {
+                        i class="fas fa-sync-alt text-lg" {}
+                    }
+                    div class="w-12 h-1 bg-gray-200 rounded-full mt-2 overflow-hidden" {
+                        div id="progress-bar" class="h-full bg-gray-400 rounded-full transition-none" style="width: 100%;" {}
+                    }
+                }
+            }
 
             a href="/admin" class="text-blue-500 hover:underline mb-4 inline-block" { "← Back to Admin Dashboard" }
 
-            div class="overflow-x-auto" {
-                table class="min-w-full bg-white border border-gray-300" {
+            div class="overflow-x-auto" id="cron-table-container" {
+                table class="min-w-full bg-white border border-gray-300" id="cron-table" {
                     thead {
                         tr class="bg-gray-100" {
                             th class="px-4 py-2 border" { "Name" }
@@ -58,6 +68,144 @@ pub(crate) async fn list_crons(
                         }
                     }
                 }
+            }
+
+            style {
+                (maud::PreEscaped(r"
+                    @keyframes spin-slow {
+                        from { transform: rotate(0deg); }
+                        to { transform: rotate(360deg); }
+                    }
+                    
+                    .spinning {
+                        animation: spin-slow 10s linear infinite;
+                    }
+                    
+                    @keyframes deplete {
+                        from { width: 100%; }
+                        to { width: 0%; }
+                    }
+                    
+                    .depleting {
+                        animation: deplete 10s linear;
+                    }
+                "))
+            }
+
+            script {
+                (maud::PreEscaped(r"
+                    const refreshButton = document.getElementById('refresh-button');
+                    const refreshIcon = refreshButton.querySelector('i');
+                    const progressBar = document.getElementById('progress-bar');
+                    let refreshInterval;
+                    let countdownInterval;
+                    let timeoutId;
+                    let secondsRemaining = 10;
+                    const REFRESH_INTERVAL_SECONDS = 10;
+                    
+                    // Function to update the title text
+                    function updateTitle() {
+                        return `Refreshes every ${REFRESH_INTERVAL_SECONDS} seconds. Next refresh in ${secondsRemaining} seconds. Click to refresh now.`;
+                    }
+                    
+                    // Update title on hover
+                    refreshButton.addEventListener('mouseenter', () => {
+                        refreshButton.title = updateTitle();
+                    });
+                    
+                    // Function to refresh the table
+                    async function refreshTable() {
+                        try {
+                            const response = await fetch('/admin/crons');
+                            const html = await response.text();
+                            
+                            const parser = new DOMParser();
+                            const doc = parser.parseFromString(html, 'text/html');
+                            const newTable = doc.getElementById('cron-table');
+                            
+                            if (!newTable) return;
+                            
+                            const currentTable = document.getElementById('cron-table');
+                            if (currentTable && currentTable.parentNode) {
+                                currentTable.parentNode.replaceChild(newTable.cloneNode(true), currentTable);
+                            }
+                        } catch (error) {
+                            console.error('Failed to refresh table:', error);
+                        }
+                    }
+                    
+                    // Function to start the refresh cycle
+                    function startRefreshCycle() {
+                        // Reset countdown
+                        secondsRemaining = REFRESH_INTERVAL_SECONDS;
+                        
+                        // Add spinning animation
+                        refreshIcon.classList.add('spinning');
+                        
+                        // Reset and start progress bar animation
+                        progressBar.classList.remove('depleting');
+                        progressBar.style.width = '100%';
+                        void progressBar.offsetWidth; // Force reflow
+                        progressBar.classList.add('depleting');
+                        
+                        // Clear any existing intervals
+                        if (refreshInterval) clearInterval(refreshInterval);
+                        if (countdownInterval) clearInterval(countdownInterval);
+                        
+                        // Set up countdown interval (every second)
+                        countdownInterval = setInterval(() => {
+                            secondsRemaining--;
+                            
+                            if (secondsRemaining <= 0) {
+                                secondsRemaining = REFRESH_INTERVAL_SECONDS;
+                            }
+                        }, 1000);
+                        
+                        // Set up refresh interval
+                        refreshInterval = setInterval(async () => {
+                            await refreshTable();
+                            // Restart the animations
+                            refreshIcon.classList.remove('spinning');
+                            void refreshIcon.offsetWidth; // Force reflow
+                            refreshIcon.classList.add('spinning');
+                            
+                            progressBar.classList.remove('depleting');
+                            progressBar.style.width = '100%';
+                            void progressBar.offsetWidth; // Force reflow
+                            progressBar.classList.add('depleting');
+                            
+                            // Reset countdown
+                            secondsRemaining = REFRESH_INTERVAL_SECONDS;
+                        }, REFRESH_INTERVAL_SECONDS * 1000);
+                    }
+                    
+                    // Manual refresh on button click
+                    refreshButton.addEventListener('click', async () => {
+                        // Clear existing timers
+                        if (refreshInterval) clearInterval(refreshInterval);
+                        if (countdownInterval) clearInterval(countdownInterval);
+                        if (timeoutId) clearTimeout(timeoutId);
+                        
+                        // Remove and re-add animations to restart them
+                        refreshIcon.classList.remove('spinning');
+                        void refreshIcon.offsetWidth; // Force reflow
+                        refreshIcon.classList.add('spinning');
+                        
+                        progressBar.classList.remove('depleting');
+                        progressBar.style.width = '100%';
+                        void progressBar.offsetWidth; // Force reflow
+                        progressBar.classList.add('depleting');
+                        
+                        // Refresh immediately
+                        await refreshTable();
+                        
+                        // Start the cycle again
+                        startRefreshCycle();
+                    });
+                    
+                    // Start the initial refresh cycle
+                    startRefreshCycle();
+                "))
             }
         },
         OpenGraph::default(),

--- a/server/src/http_server/admin/crons.rs
+++ b/server/src/http_server/admin/crons.rs
@@ -1,0 +1,92 @@
+use axum::{extract::State, response::IntoResponse, Form};
+use maud::html;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::state::AppState;
+
+use super::{
+    super::{
+        auth::session::AdminUser,
+        errors::ServerError,
+        templates::{base_constrained, header::OpenGraph},
+    },
+    Timestamp,
+};
+
+pub(crate) async fn list_crons(
+    _admin: AdminUser,
+    State(app_state): State<AppState>,
+) -> Result<impl IntoResponse, ServerError> {
+    let crons = sqlx::query!(
+        "SELECT cron_id, name, last_run_at, created_at, updated_at FROM Crons ORDER BY name"
+    )
+    .fetch_all(&app_state.db)
+    .await?;
+
+    Ok(base_constrained(
+        html! {
+            h1 class="text-xl mb-4" { "Cron Management" }
+
+            a href="/admin" class="text-blue-500 hover:underline mb-4 inline-block" { "← Back to Admin Dashboard" }
+
+            div class="overflow-x-auto" {
+                table class="min-w-full bg-white border border-gray-300" {
+                    thead {
+                        tr class="bg-gray-100" {
+                            th class="px-4 py-2 border" { "Name" }
+                            th class="px-4 py-2 border" { "Last Run At" }
+                            th class="px-4 py-2 border" { "Created At" }
+                            th class="px-4 py-2 border" { "Updated At" }
+                            th class="px-4 py-2 border" { "Actions" }
+                        }
+                    }
+                    tbody {
+                        @for cron in crons {
+                            tr {
+                                td class="px-4 py-2 border" { (cron.name) }
+                                td class="px-4 py-2 border" { (Timestamp(cron.last_run_at)) }
+                                td class="px-4 py-2 border" { (Timestamp(cron.created_at)) }
+                                td class="px-4 py-2 border" { (Timestamp(cron.updated_at)) }
+                                td class="px-4 py-2 border text-center" {
+                                    form action="/admin/crons/reset" method="post" class="inline" {
+                                        input type="hidden" name="cron_id" value=(cron.cron_id.to_string());
+                                        input type="submit" value="Reset Last Run" class="px-3 py-1 bg-red-500 text-white rounded hover:bg-red-600 cursor-pointer";
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        OpenGraph::default(),
+    ))
+}
+
+#[derive(Deserialize)]
+pub(crate) struct ResetCronForm {
+    cron_id: Uuid,
+}
+
+pub(crate) async fn reset_cron(
+    _admin: AdminUser,
+    State(app_state): State<AppState>,
+    Form(form): Form<ResetCronForm>,
+) -> Result<impl IntoResponse, ServerError> {
+    // Set last_run_at to a very old date (epoch) to ensure the cron will run on next check
+    let epoch = chrono::DateTime::parse_from_rfc3339("1970-01-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+
+    sqlx::query!(
+        "UPDATE Crons SET last_run_at = $1, updated_at = NOW() WHERE cron_id = $2",
+        epoch,
+        form.cron_id
+    )
+    .execute(&app_state.db)
+    .await?;
+
+    // Redirect back to the crons list
+    Ok(axum::response::Redirect::to("/admin/crons"))
+}

--- a/server/src/http_server/admin/mod.rs
+++ b/server/src/http_server/admin/mod.rs
@@ -11,6 +11,7 @@ use super::{
 };
 
 pub(crate) mod auth;
+pub(crate) mod crons;
 pub(crate) mod job_routes;
 
 pub(crate) async fn dashboard(
@@ -46,6 +47,10 @@ pub(crate) async fn dashboard(
     Ok(base_constrained(
         html! {
             h1 class="text-xl" { "Admin Dashboard" }
+
+            div class="my-4" {
+                a href="/admin/crons" class="text-blue-500 hover:underline" { "Manage Crons →" }
+            }
 
             h3 class="py-2 text-lg" { "Last Refresh Ats" }
             @for last_refresh_at in last_refresh_ats {

--- a/server/src/http_server/components/auto_refresh.rs
+++ b/server/src/http_server/components/auto_refresh.rs
@@ -1,0 +1,203 @@
+use maud::{html, Markup, PreEscaped};
+
+/// A reusable auto-refresh button component with visual countdown
+///
+/// # Example
+/// ```
+/// // Basic usage - refreshes #my-content every 10 seconds
+/// AutoRefreshButton::new("#my-content", "/api/data").render()
+///
+/// // With custom interval - refreshes every 30 seconds  
+/// AutoRefreshButton::new("#my-table", "/api/table-data")
+///     .with_interval(30)
+///     .render()
+/// ```
+pub struct AutoRefreshButton {
+    /// CSS selector for the element to refresh
+    pub target_selector: String,
+    /// Interval in seconds between refreshes
+    pub interval_seconds: u32,
+    /// URL to fetch for refresh content
+    pub fetch_url: Option<String>,
+}
+
+impl Default for AutoRefreshButton {
+    fn default() -> Self {
+        Self {
+            target_selector: "#content".to_string(),
+            interval_seconds: 10,
+            fetch_url: None,
+        }
+    }
+}
+
+impl AutoRefreshButton {
+    pub fn new(target_selector: impl Into<String>, fetch_url: Option<impl Into<String>>) -> Self {
+        Self {
+            target_selector: target_selector.into(),
+            interval_seconds: 10,
+            fetch_url: fetch_url.map(|url| url.into()),
+        }
+    }
+
+    pub fn with_interval(mut self, seconds: u32) -> Self {
+        self.interval_seconds = seconds;
+        self
+    }
+
+    #[allow(clippy::too_many_lines)]
+    pub fn render(&self) -> Markup {
+        html! {
+            div class="flex flex-col items-center auto-refresh-container"
+                data-target=(self.target_selector)
+                data-url=[self.fetch_url.as_ref()]
+                data-interval=(self.interval_seconds) {
+                button class="auto-refresh-button text-gray-600 hover:text-gray-800 transition-colors"
+                    title=(format!("Refreshes every {} seconds. Next refresh in {} seconds. Click to refresh now.", self.interval_seconds, self.interval_seconds)) {
+                    i class="fas fa-sync-alt text-lg auto-refresh-icon" {}
+                }
+                div class="w-12 h-1 bg-gray-200 rounded-full mt-2 overflow-hidden" {
+                    div class="auto-refresh-progress h-full bg-gray-400 rounded-full transition-none" style="width: 100%;" {}
+                }
+            }
+
+            style {
+                (PreEscaped(format!(r"
+                    @keyframes spin-slow {{
+                        from {{ transform: rotate(0deg); }}
+                        to {{ transform: rotate(360deg); }}
+                    }}
+                    
+                    .spinning {{
+                        animation: spin-slow {}s linear infinite;
+                    }}
+                    
+                    @keyframes deplete {{
+                        from {{ width: 100%; }}
+                        to {{ width: 0%; }}
+                    }}
+                    
+                    .depleting {{
+                        animation: deplete {}s linear;
+                    }}
+                ", self.interval_seconds, self.interval_seconds)))
+            }
+
+            script {
+                (PreEscaped(r"
+                    // Initialize all auto-refresh containers on the page
+                    document.querySelectorAll('.auto-refresh-container').forEach(container => {
+                        const refreshButton = container.querySelector('.auto-refresh-button');
+                        const refreshIcon = container.querySelector('.auto-refresh-icon');
+                        const progressBar = container.querySelector('.auto-refresh-progress');
+                        
+                        // Read configuration from data attributes
+                        const targetSelector = container.dataset.target;
+                        const fetchUrl = container.dataset.url || window.location.href;
+                        const REFRESH_INTERVAL_SECONDS = parseInt(container.dataset.interval);
+                        
+                        let refreshInterval;
+                        let countdownInterval;
+                        let cycleStartTime = Date.now();
+                        
+                        // Function to calculate seconds remaining
+                        function getSecondsRemaining() {{
+                            const elapsed = (Date.now() - cycleStartTime) / 1000;
+                            const remaining = Math.max(0, REFRESH_INTERVAL_SECONDS - elapsed);
+                            return Math.ceil(remaining);
+                        }}
+                        
+                        // Function to update the title text
+                        function updateTitle() {{
+                            const secondsRemaining = getSecondsRemaining();
+                            return `Refreshes every ${{REFRESH_INTERVAL_SECONDS}} seconds. Next refresh in ${{secondsRemaining}} seconds. Click to refresh now.`;
+                        }}
+                        
+                        // Function to restart animations
+                        function restartAnimations() {{
+                            // Restart icon spinning animation
+                            refreshIcon.classList.remove('spinning');
+                            void refreshIcon.offsetWidth; // Force reflow
+                            refreshIcon.classList.add('spinning');
+                            
+                            // Restart progress bar animation
+                            progressBar.classList.remove('depleting');
+                            progressBar.style.width = '100%';
+                            void progressBar.offsetWidth; // Force reflow
+                            progressBar.classList.add('depleting');
+                        }}
+                        
+                        // Update title on hover
+                        refreshButton.addEventListener('mouseenter', () => {{
+                            refreshButton.title = updateTitle();
+                        }});
+                        
+                        // Function to refresh the content
+                        async function refreshContent() {{
+                            try {{
+                                const response = await fetch(fetchUrl);
+                                const html = await response.text();
+                                
+                                const parser = new DOMParser();
+                                const doc = parser.parseFromString(html, 'text/html');
+                                const newContent = doc.querySelector(targetSelector);
+                                
+                                if (!newContent) return;
+                                
+                                const currentContent = document.querySelector(targetSelector);
+                                if (currentContent && currentContent.parentNode) {{
+                                    currentContent.parentNode.replaceChild(newContent.cloneNode(true), currentContent);
+                                }}
+                            }} catch (error) {{
+                                console.error('Failed to refresh content:', error);
+                            }}
+                        }}
+                        
+                        // Function to start the refresh cycle
+                        function startRefreshCycle() {{
+                            // Reset cycle start time
+                            cycleStartTime = Date.now();
+                            
+                            // Start animations
+                            restartAnimations();
+                            
+                            
+                            // Clear any existing intervals
+                            if (refreshInterval) clearInterval(refreshInterval);
+                            if (countdownInterval) clearInterval(countdownInterval);
+                            
+                            // Set up refresh interval
+                            refreshInterval = setInterval(async () => {{
+                                await refreshContent();
+                                // Restart the animations
+                                restartAnimations();
+                                
+                                // Reset cycle start time
+                                cycleStartTime = Date.now();
+                            }}, REFRESH_INTERVAL_SECONDS * 1000);
+                        }}
+                        
+                        // Manual refresh on button click
+                        refreshButton.addEventListener('click', async () => {{
+                            // Clear existing timers
+                            if (refreshInterval) clearInterval(refreshInterval);
+                            if (countdownInterval) clearInterval(countdownInterval);
+                            
+                            // Restart animations
+                            restartAnimations();
+                            
+                            // Refresh immediately
+                            await refreshContent();
+                            
+                            // Start the cycle again
+                            startRefreshCycle();
+                        }});
+                        
+                        // Start the initial refresh cycle
+                        startRefreshCycle();
+                    });
+                "))
+            }
+        }
+    }
+}

--- a/server/src/http_server/components/mod.rs
+++ b/server/src/http_server/components/mod.rs
@@ -1,0 +1,3 @@
+pub mod auto_refresh;
+
+pub use auto_refresh::AutoRefreshButton;

--- a/server/src/http_server/config.rs
+++ b/server/src/http_server/config.rs
@@ -7,8 +7,6 @@ use crate::{google::GoogleConfig, twitch::TwitchConfig, AppConfig, AppState};
 
 use super::pages::blog::md::SyntaxHighlightingContext;
 
-
-
 impl FromRef<AppState> for TwitchConfig {
     fn from_ref(config: &AppState) -> Self {
         config.twitch.clone()

--- a/server/src/http_server/mod.rs
+++ b/server/src/http_server/mod.rs
@@ -26,6 +26,7 @@ use self::{
 };
 
 pub(crate) mod cmd;
+pub(crate) mod components;
 
 pub(crate) mod pages;
 

--- a/server/src/http_server/routes.rs
+++ b/server/src/http_server/routes.rs
@@ -58,6 +58,8 @@ pub(crate) fn make_router(syntax_css: String) -> Router<AppState> {
             post(admin::job_routes::refresh_youtube),
         )
         .route("/admin", get(admin::dashboard))
+        .route("/admin/crons", get(admin::crons::list_crons))
+        .route("/admin/crons/reset", post(admin::crons::reset_cron))
         .route("/webhooks/cookd", post(webhooks::cookd::handler))
         .route("/bytes", get(pages::bytes::bytes_index))
         .route("/bytes/:slug", get(pages::bytes::byte_get))

--- a/server/src/http_server/templates/header.rs
+++ b/server/src/http_server/templates/header.rs
@@ -52,6 +52,9 @@ pub fn head(og: impl Borrow<OpenGraph>) -> Markup {
         link rel="stylesheet" href="/styles/syntax.css" {}
         link rel="stylesheet" href="/styles/comic_code.css" {}
 
+        link rel="stylesheet" href="/static/view-transitions.css" {}
+        script src="/static/view-transitions.js" defer {}
+
         link rel="preconnect" href="https://fonts.googleapis.com" {}
         link rel="preconnect" href="https://fonts.gstatic.com" crossorigin {}
         link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@300;400;500;600;700&&display=block" rel="stylesheet" {}

--- a/server/src/jobs/standup_message.rs
+++ b/server/src/jobs/standup_message.rs
@@ -17,7 +17,7 @@ impl Job<AppState> for StandupMessage {
         // Get current time in Eastern timezone
         let now_utc = Utc::now();
         let now_eastern = now_utc.with_timezone(&Eastern);
-        
+
         // Check if we're in the 7-8am Eastern time window
         let hour = now_eastern.hour();
         if hour != 7 {
@@ -29,10 +29,9 @@ impl Job<AppState> for StandupMessage {
         }
 
         // Get the channel ID from app state config
-        let channel_id = app_state
-            .standup
-            .discord_channel_id
-            .ok_or_else(|| cja::color_eyre::eyre::eyre!("DAILY_MESSAGE_DISCORD_CHANNEL_ID not configured"))?;
+        let channel_id = app_state.standup.discord_channel_id.ok_or_else(|| {
+            cja::color_eyre::eyre::eyre!("DAILY_MESSAGE_DISCORD_CHANNEL_ID not configured")
+        })?;
 
         // Create the standup message with Discord mention
         let message_content = format!(
@@ -49,7 +48,10 @@ impl Job<AppState> for StandupMessage {
             .await
             .map_err(|e| cja::color_eyre::eyre::eyre!("Failed to send Discord message: {}", e))?;
 
-        tracing::info!("Standup message sent successfully to channel {}", channel_id);
+        tracing::info!(
+            "Standup message sent successfully to channel {}",
+            channel_id
+        );
 
         Ok(())
     }

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -30,7 +30,7 @@ impl StandupConfig {
         let discord_channel_id = std::env::var("DAILY_MESSAGE_DISCORD_CHANNEL_ID")
             .ok()
             .and_then(|id| id.parse::<u64>().ok());
-        
+
         Ok(Self { discord_channel_id })
     }
 }

--- a/server/src/styles/tailwind.css
+++ b/server/src/styles/tailwind.css
@@ -16,3 +16,4 @@
 .source.rust .block {
   display: unset;
 }
+

--- a/server/static/view-transitions.css
+++ b/server/static/view-transitions.css
@@ -1,0 +1,3 @@
+@view-transition {
+  navigation: auto;
+}

--- a/server/static/view-transitions.js
+++ b/server/static/view-transitions.js
@@ -1,0 +1,15 @@
+// Scroll restoration for view transitions
+window.addEventListener('pageswap', (event) => {
+    sessionStorage.setItem('scrollPosition', window.scrollY.toString());
+});
+
+window.addEventListener('pagereveal', (event) => {
+    const savedPosition = sessionStorage.getItem('scrollPosition');
+    if (savedPosition && navigation?.activation?.from && navigation?.activation?.entry) {
+        const fromURL = new URL(navigation.activation.from.url);
+        const currentURL = new URL(navigation.activation.entry.url);
+        if (fromURL.pathname === currentURL.pathname) {
+            window.scrollTo(0, parseInt(savedPosition));
+        }
+    }
+});


### PR DESCRIPTION
## Summary
- Added a new admin-only page at `/admin/crons` to view and manage CronRecords
- Implemented auto-refresh functionality with visual countdown indicators
- Extracted the refresh functionality into a reusable `AutoRefreshButton` component

## Features

### CronRecords Management Page
- Displays all cron jobs in a table showing name, last run time, created/updated timestamps
- "Reset Last Run" button sets `last_run_at` to epoch time, forcing the cron to run on next check
- Protected with `AdminUser` authentication
- Linked from main admin dashboard

### Auto-Refresh Functionality
- Spinning refresh icon that rotates over the refresh interval
- Progress bar that depletes to show countdown to next refresh
- Dynamic tooltip showing seconds until next refresh (updates on hover)
- Manual refresh button to trigger immediate update
- Smooth View Transitions support for all navigation

### Reusable Component
- Created `AutoRefreshButton` component that can be used on any page
- Uses data attributes instead of JS interpolation for cleaner code
- Configurable target selector, fetch URL, and refresh interval
- Encapsulated HTML, CSS, and JavaScript
- Supports multiple instances on the same page with class-based selectors

## Implementation Details
- Uses server-driven approach with minimal JavaScript
- View Transitions CSS (`navigation: auto`) for smooth page transitions
- Scroll position preservation across navigations
- Component reads configuration from data attributes (data-target, data-url, data-interval)

## Test plan
- [x] Clippy passes with no warnings
- [x] All tests pass
- [ ] Manual testing on the admin crons page
- [ ] Verify refresh functionality works correctly
- [ ] Test scroll position preservation
- [ ] Ensure admin authentication is enforced

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>