### PR TITLE
Add aborted status for agent threads that hit max message limit

### DIFF
--- a/.sqlx/query-01723d2cf1dadc4b7ff9146c297f4ec7809cfeaef4175763350ad18516ad2c8a.json
+++ b/.sqlx/query-01723d2cf1dadc4b7ff9146c297f4ec7809cfeaef4175763350ad18516ad2c8a.json
@@ -1,0 +1,71 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE threads\n            SET status = 'aborted', result = $1, updated_at = NOW()\n            WHERE thread_id = $2\n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "thread_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "branching_stitch_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "goal",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "tasks",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "status",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "result",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 6,
+        "name": "pending_child_results",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 7,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Jsonb",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "01723d2cf1dadc4b7ff9146c297f4ec7809cfeaef4175763350ad18516ad2c8a"
+}

--- a/db/migrations/20250718100811_AddAbortedStatusToThreads.down.sql
+++ b/db/migrations/20250718100811_AddAbortedStatusToThreads.down.sql
@@ -1,0 +1,13 @@
+-- Remove 'aborted' from valid status values
+ALTER TABLE threads
+DROP CONSTRAINT threads_status_check;
+
+ALTER TABLE threads ADD CONSTRAINT threads_status_check CHECK (
+    status IN (
+        'pending',
+        'running',
+        'waiting',
+        'completed',
+        'failed'
+    )
+);

--- a/db/migrations/20250718100811_AddAbortedStatusToThreads.up.sql
+++ b/db/migrations/20250718100811_AddAbortedStatusToThreads.up.sql
@@ -1,0 +1,14 @@
+-- Add 'aborted' as a valid status for agentic threads
+ALTER TABLE threads
+DROP CONSTRAINT threads_status_check;
+
+ALTER TABLE threads ADD CONSTRAINT threads_status_check CHECK (
+    status IN (
+        'pending',
+        'running',
+        'waiting',
+        'completed',
+        'failed',
+        'aborted'
+    )
+);

--- a/db/src/agentic_threads/mod.rs
+++ b/db/src/agentic_threads/mod.rs
@@ -285,6 +285,28 @@ impl Thread {
 
         Ok(count.count.unwrap_or(0))
     }
+
+    pub async fn abort(
+        pool: &PgPool,
+        id: Uuid,
+        result: JsonValue,
+    ) -> color_eyre::Result<Option<Self>> {
+        let thread = sqlx::query_as!(
+            Thread,
+            r#"
+            UPDATE threads
+            SET status = 'aborted', result = $1, updated_at = NOW()
+            WHERE thread_id = $2
+            RETURNING *
+            "#,
+            result,
+            id
+        )
+        .fetch_optional(pool)
+        .await?;
+
+        Ok(thread)
+    }
 }
 
 impl Stitch {

--- a/server/src/al/tools/discord.rs
+++ b/server/src/al/tools/discord.rs
@@ -28,7 +28,27 @@ pub struct DiscordInput {
 #[async_trait::async_trait]
 impl Tool for SendDiscordMessage {
     const NAME: &'static str = "send_discord_message";
-    const DESCRIPTION: &'static str = "Send a message to a Discord channel. The message and channel id are required. And the list of users to tag is optional. YOU MUST INCLUDE A MESSAGE TO SEND";
+    const DESCRIPTION: &'static str = r#"
+    Send a message to a Discord channel. The message and channel id are required. And the list of users to tag is optional. YOU MUST INCLUDE A MESSAGE TO SEND
+
+    Example:
+    ```json
+    {
+        "channel_id": 1234567890,
+        "user_id": [1234567890],
+        "message": "Hello, world!"
+    }
+    ```
+
+    Example Multiple Users:
+    ```json
+    {
+        "channel_id": 1234567890,
+        "user_id": [1234567890, 1234567891],
+        "message": "Hello, world!"
+    }
+    ```
+    "#;
 
     type ToolInput = DiscordInput;
     type ToolOutput = ();

--- a/server/src/http_server/mod.rs
+++ b/server/src/http_server/mod.rs
@@ -38,7 +38,6 @@ mod templates;
 
 pub(crate) mod auth;
 
-
 pub(crate) mod admin;
 
 pub(crate) mod api;

--- a/thread-frontend/src/components/ThreadNode.tsx
+++ b/thread-frontend/src/components/ThreadNode.tsx
@@ -16,6 +16,7 @@ const statusColors = {
   waiting: '#3B82F6', // blue
   completed: '#10B981', // green
   failed: '#EF4444', // red
+  aborted: '#DC2626', // dark red
 }
 
 export const ThreadNode: React.FC<ThreadNodeProps> = ({ data }) => {

--- a/thread-frontend/src/types/index.ts
+++ b/thread-frontend/src/types/index.ts
@@ -50,7 +50,7 @@ export interface Thread {
   branching_stitch_id: string | null
   goal: string
   tasks: Task[]
-  status: 'pending' | 'running' | 'waiting' | 'completed' | 'failed'
+  status: 'pending' | 'running' | 'waiting' | 'completed' | 'failed' | 'aborted'
   result: ThreadResult | null
   pending_child_results: ChildResult[]
   created_at: string


### PR DESCRIPTION
- Add 'aborted' as a new thread status in database migration
- Add Thread::abort() method to mark threads as aborted
- Refactor standup agent error handling to use StandupLoopError enum
- Update agent to abort threads when hitting max message limit (100 messages)
- Update frontend to display aborted threads in dark red (#DC2626)
- Use proper error enum instead of string matching for cleaner error handling