### PR TITLE
Add cache_control to Anthropic API messages

### DIFF
--- a/server/src/al/standup.rs
+++ b/server/src/al/standup.rs
@@ -31,6 +31,13 @@ pub struct ToolChoice {
 pub struct Message {
     pub role: String,
     pub content: Vec<Content>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CacheControl {
+    pub r#type: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
This adds cache_control with type "ephemeral" to the last message in the message chain when sending requests to the Anthropic API. This enables Claude to use its cache for better performance on subsequent API calls within the same conversation thread.

Add tests for cache_control JSON serialization

Added comprehensive tests to verify:
- cache_control is properly added to the last message in reconstruct_messages
- JSON serialization produces the expected structure
- Messages without cache_control don't include the field in JSON