### PR TITLE
Fix system prompt handling for Anthropic API

### DIFF
--- a/.sqlx/query-7959570857eadf24cb4e4f2cb8b766b94dc2efe3b3b1e10bccce3a80a154b3c6.json
+++ b/.sqlx/query-7959570857eadf24cb4e4f2cb8b766b94dc2efe3b3b1e10bccce3a80a154b3c6.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO stitches (thread_id, previous_stitch_id, stitch_type, llm_request)\n            VALUES ($1, NULL, 'system_prompt', $2)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7959570857eadf24cb4e4f2cb8b766b94dc2efe3b3b1e10bccce3a80a154b3c6"
+}

--- a/.sqlx/query-e118f220e3418075b2604a4ecdb45fc2c33b83d867828bd172d93091d244635b.json
+++ b/.sqlx/query-e118f220e3418075b2604a4ecdb45fc2c33b83d867828bd172d93091d244635b.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            INSERT INTO stitches (thread_id, previous_stitch_id, stitch_type, llm_request)\n            VALUES ($1, NULL, 'initial_prompt', $2)\n            RETURNING *\n            ",
+  "query": "\n            INSERT INTO stitches (thread_id, previous_stitch_id, stitch_type, llm_request)\n            VALUES ($1, NULL, 'system_prompt', $2)\n            RETURNING *\n            ",
   "describe": {
     "columns": [
       {
@@ -85,5 +85,5 @@
       false
     ]
   },
-  "hash": "219f25453149ed79d24995121c618cb98d17aaedb205599c02ba0f41338730de"
+  "hash": "e118f220e3418075b2604a4ecdb45fc2c33b83d867828bd172d93091d244635b"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,143 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This is coreyja.com - a personal website built with:
+
+- **Backend**: Rust with Axum web framework
+- **Frontend**: Server-side rendered HTML (Maud templates) for most pages
+- **Admin UI**: React + TypeScript for the thread visualization page only
+- **Database**: PostgreSQL with SQLx
+- **Version Control**: Uses `jj` instead of `git`
+
+## Build Commands
+
+### Quick Build
+
+```bash
+# Full build (frontend + Rust release)
+./scripts/build-all.sh
+
+# Development build (frontend + Rust debug)
+./scripts/dev-build.sh
+
+# Frontend only
+./scripts/build-frontend.sh
+```
+
+**IMPORTANT**: Do not run the server binary or `./scripts/start.sh` as it starts an interactive web server that will block the terminal.
+
+## Development Commands
+
+### Auto-fix and Format
+
+```bash
+# Fix all linting/formatting issues
+# This also generates the sqlx files we need to checkin to the repo
+./scripts/auto-fix-all.sh
+```
+
+### Frontend Development
+
+```bash
+cd thread-frontend
+npm run dev          # Start dev server
+npm run test         # Run tests
+npm run test:ui      # Run tests with UI
+npm run lint         # Check linting
+npm run lint:fix     # Fix linting issues
+npm run format       # Format code
+npm run typecheck    # Type checking
+```
+
+### Rust Development
+
+```bash
+# Run tests
+cargo test
+cargo test --workspace
+
+# Run specific test
+cargo test test_name
+
+# Linting and formatting
+cargo clippy --all-targets --all-features --workspace --tests
+cargo fmt
+
+# Database operations. From the `db` directory.
+cargo sqlx migrate run
+cargo sqlx prepare --all --workspace -- --all-targets # This is also part of the auto-fix-all.sh script
+```
+
+## Architecture
+
+### Workspace Structure
+
+- **`/server`** - Main web server (Axum)
+- **`/db`** - Database models and migrations
+- **`/posts`** - Blog post handling
+- **`/thread-frontend`** - React admin UI for thread visualization (built and embedded into server binary)
+
+### Key Technologies
+
+- **Web Framework**: Axum with Tower middleware
+- **Database**: PostgreSQL with SQLx (compile-time checked queries)
+- **Frontend**: Maud templates for server-side HTML generation
+- **Admin UI**: React with TanStack Router/Query for thread visualization only
+- **Templating**: Maud for server-side HTML generation
+- **Admin Authentication**: GitHub/Google OAuth, JWT sessions
+- **Discord Bot**: Serenity framework with Poise commands
+- **AI Agent**: Thread and stitch data model for agent interactions
+
+### Database
+
+- Migrations in `/db/migrations/`
+- Uses SQLx with compile-time query verification
+- Environment variable: `DATABASE_URL=postgres://localhost:5432/byte`
+
+### Frontend Architecture
+
+The site uses two approaches for the frontend:
+
+1. **Main Site**: Server-side rendered HTML using Maud templates
+2. **Admin Thread Viewer**: React SPA for interactive thread/stitch visualization
+
+The React admin UI is built and embedded into the Rust binary at compile time:
+
+1. React app built with Vite (located in `/thread-frontend`)
+2. Assets included in Rust binary using `include_dir!`
+3. Served by Axum for the admin interface
+
+## Version Control with jj
+
+This project uses `jj` instead of `git`:
+
+```bash
+jj describe -m "commit message"  # Describe current change
+jj new                          # Create new change
+jj status                       # Show status
+jj log                         # Show history
+```
+
+Don't run a `jj describe` without first running `jj status` to understand if the current changes already have a description.
+
+You should prefer to start new work in a new commit. Use `jj status` to understand if you are currently in an empty commit. If so proceed. If not, you should make a new commit. First we need to check if the current commit has a description. If it does, you are free to make a new commit with `jj new`. If it does not you should first run `jj diff` to understand the current commit. Then describe it, before making a new commit.
+
+## Environment Setup
+
+Required environment variables (see `.envrc` for full list):
+
+- `DATABASE_URL` - PostgreSQL connection
+- `APP_BASE_URL` - Application base URL
+- Various API keys for integrations (GitHub, Google, OpenAI, etc.)
+
+## Testing Approach
+
+Follow TDD when writing code:
+
+1. Write minimal test first
+2. Implement code to pass test
+3. Write next test and implement
+4. Continue iteratively

--- a/db/migrations/20250804133028_AddSystemPromptStitchType.down.sql
+++ b/db/migrations/20250804133028_AddSystemPromptStitchType.down.sql
@@ -1,0 +1,8 @@
+-- Revert the stitch_type check constraint to remove system_prompt
+
+-- First drop the existing constraint
+ALTER TABLE stitches DROP CONSTRAINT IF EXISTS stitches_stitch_type_check;
+
+-- Add back the original constraint without system_prompt
+ALTER TABLE stitches ADD CONSTRAINT stitches_stitch_type_check
+CHECK (stitch_type IN ('initial_prompt', 'llm_call', 'tool_call', 'thread_result', 'discord_message'));

--- a/db/migrations/20250804133028_AddSystemPromptStitchType.up.sql
+++ b/db/migrations/20250804133028_AddSystemPromptStitchType.up.sql
@@ -1,0 +1,9 @@
+-- Add system_prompt to the stitch_type check constraint
+-- This allows us to separate system prompts from initial user messages
+
+-- First drop the existing constraint
+ALTER TABLE stitches DROP CONSTRAINT IF EXISTS stitches_stitch_type_check;
+
+-- Add the new constraint with system_prompt included
+ALTER TABLE stitches ADD CONSTRAINT stitches_stitch_type_check
+CHECK (stitch_type IN ('initial_prompt', 'llm_call', 'tool_call', 'thread_result', 'discord_message', 'system_prompt'));

--- a/db/src/agentic_threads/mod.rs
+++ b/db/src/agentic_threads/mod.rs
@@ -18,6 +18,8 @@ pub enum StitchType {
     ThreadResult,
     #[serde(rename = "discord_message")]
     DiscordMessage,
+    #[serde(rename = "system_prompt")]
+    SystemPrompt,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
@@ -56,6 +58,7 @@ impl fmt::Display for StitchType {
             StitchType::ToolCall => write!(f, "tool_call"),
             StitchType::ThreadResult => write!(f, "thread_result"),
             StitchType::DiscordMessage => write!(f, "discord_message"),
+            StitchType::SystemPrompt => write!(f, "system_prompt"),
         }
     }
 }
@@ -70,6 +73,7 @@ impl std::str::FromStr for StitchType {
             "tool_call" => Ok(StitchType::ToolCall),
             "thread_result" => Ok(StitchType::ThreadResult),
             "discord_message" => Ok(StitchType::DiscordMessage),
+            "system_prompt" => Ok(StitchType::SystemPrompt),
             _ => Err(format!("Unknown stitch type: {s}")),
         }
     }
@@ -600,20 +604,14 @@ impl Stitch {
         system_prompt: String,
     ) -> color_eyre::Result<Self> {
         let request = json!({
-            "messages": [{
-                "role": "system",
-                "content": [{
-                    "type": "text",
-                    "text": system_prompt
-                }]
-            }]
+            "text": system_prompt
         });
 
         let stitch = sqlx::query_as!(
             Stitch,
             r#"
             INSERT INTO stitches (thread_id, previous_stitch_id, stitch_type, llm_request)
-            VALUES ($1, NULL, 'initial_prompt', $2)
+            VALUES ($1, NULL, 'system_prompt', $2)
             RETURNING *
             "#,
             thread_id,

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,91 @@
+# Plan: Fix System Prompt Handling for Anthropic API
+
+## Problem
+The current implementation includes system messages in the messages array, which is not allowed by the Anthropic API. System prompts should be provided as a top-level `system` parameter in the request, not as a message with role "system" in the messages array.
+There is also a Rust enum. There's just not a database enum. We do want to update the Rust enum, of course.
+## Current Implementation Issues
+
+1. **In `thread_processor.rs`**:
+   - The `reconstruct_messages` function includes system messages in the messages array
+   - The `AnthropicRequest` struct doesn't have a `system` field
+
+2. **In `db/src/agentic_threads/mod.rs`**:
+   - `create_system_prompt` stores the system prompt as a message with role "system" in the messages array
+   - System prompts are stored as `InitialPrompt` stitch type, which is also used for initial user messages
+
+## Required Changes
+
+### 1. Add new `SystemPrompt` stitch type
+- Update the database check constraint to include 'system_prompt' as a valid stitch_type value
+- This will cleanly separate system prompts from initial user messages
+- Add `SystemPrompt` variant to the `StitchType` enum in Rust code (`db/src/agentic_threads/mod.rs`)
+
+### 2. Update `AnthropicRequest` struct (`server/src/al/standup.rs`)
+- Add an optional `system` field to the struct:
+  ```rust
+  pub struct AnthropicRequest {
+      pub model: String,
+      pub max_tokens: u32,
+      pub system: Option<String>,  // Add this field
+      pub messages: Vec<Message>,
+      pub tools: Vec<AnthropicTool>,
+      pub tool_choice: Option<ToolChoice>,
+  }
+  ```
+
+### 3. Create new `extract_system_prompt` function (`server/src/jobs/thread_processor.rs`)
+- Create a new function that returns `Option<String>`
+- Look for a `SystemPrompt` stitch type
+- Extract and return the system prompt text from the `llm_request` field (expecting format: `{"text": "system prompt content"}`)
+- Error if multiple system prompts are found in a thread
+
+### 4. Update `reconstruct_messages` function (`server/src/jobs/thread_processor.rs`)
+- Add a new match arm for `SystemPrompt` stitch type that does nothing (skip it)
+- Remove the current logic that handles system messages within `InitialPrompt`
+- Only process actual initial user messages from `InitialPrompt` stitches
+
+### 5. Update `process_single_step` function (`server/src/jobs/thread_processor.rs`)
+- Call `extract_system_prompt` to get the system prompt
+- Pass the system prompt to the `AnthropicRequest` constructor
+- Update the match statement for previous stitch types to include `SystemPrompt`
+
+### 6. Update `create_system_prompt` function (`db/src/agentic_threads/mod.rs`)
+- Change to use the new `SystemPrompt` stitch type instead of `InitialPrompt`
+- Store the system prompt in `llm_request` as: `{"text": "system prompt content"}`
+- Update the SQL query to use 'system_prompt' as the stitch_type
+
+### 7. Database Migration
+- Create a migration to update the check constraint on the stitch_type column to include 'system_prompt'
+- The migration will need to:
+  - Drop the existing check constraint
+  - Add a new check constraint that includes 'system_prompt' as a valid value
+
+### 8. Update tests
+- All tests in `thread_processor.rs` that involve system prompts need to be updated
+- `test_reconstruct_messages_with_system_prompt` should verify system messages are excluded from the messages array
+- Add new tests for `extract_system_prompt` function
+- Update test that creates system prompts to use the new stitch type
+
+## Implementation Order
+
+1. Create database migration to update the stitch_type check constraint
+2. Add `SystemPrompt` to the `StitchType` enum in the Rust code
+3. Update the `AnthropicRequest` struct to add the `system` field
+4. Update `create_system_prompt` to use the new stitch type
+5. Create the new `extract_system_prompt` function
+6. Update `reconstruct_messages` to handle the new stitch type
+7. Update `process_single_step` to use both functions
+8. Update all affected tests
+9. Run tests to ensure everything works correctly
+
+## Testing Strategy
+
+1. Unit tests should verify:
+   - System prompts are extracted correctly
+   - Messages array only contains user and assistant messages
+   - The API request is formed correctly with system as a top-level field
+   - Error is thrown when multiple system prompts exist in a thread
+
+2. Integration testing should verify:
+   - The Anthropic API accepts the new request format
+   - System prompts are properly applied to the model's behavior

--- a/server/.sqlx/query-028a537272f06ce62e878fcb6e8718b24a72ed16814804fbdfa5349d5f144f79.json
+++ b/server/.sqlx/query-028a537272f06ce62e878fcb6e8718b24a72ed16814804fbdfa5349d5f144f79.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE Sessions\n        SET user_id = $1\n        WHERE session_id = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "028a537272f06ce62e878fcb6e8718b24a72ed16814804fbdfa5349d5f144f79"
+}

--- a/server/.sqlx/query-029bb2cc95b18502290c02344bd12b17737fde9c53dd930dabed0ba5cab6d780.json
+++ b/server/.sqlx/query-029bb2cc95b18502290c02344bd12b17737fde9c53dd930dabed0ba5cab6d780.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n    SELECT * FROM GithubLoginStates\n    WHERE github_login_state_id = $1 AND state = 'created'\n    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "github_login_state_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "github_link_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "app",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "state",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "return_to",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "029bb2cc95b18502290c02344bd12b17737fde9c53dd930dabed0ba5cab6d780"
+}

--- a/server/.sqlx/query-240735dac256824efedb9357c367ee147865da2729737db7171ba4d0d20bb285.json
+++ b/server/.sqlx/query-240735dac256824efedb9357c367ee147865da2729737db7171ba4d0d20bb285.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT youtube_video_id FROM YoutubeVideos WHERE external_youtube_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "youtube_video_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "240735dac256824efedb9357c367ee147865da2729737db7171ba4d0d20bb285"
+}

--- a/server/.sqlx/query-31f6ff0cd80d38a5d9251eda7718e708407c87a43e25cbfbff6d5372a1ac950f.json
+++ b/server/.sqlx/query-31f6ff0cd80d38a5d9251eda7718e708407c87a43e25cbfbff6d5372a1ac950f.json
@@ -1,0 +1,76 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM GithubLinks WHERE user_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "github_link_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "external_github_login",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "external_github_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "access_token_expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "refresh_token_expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "encrypted_access_token",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 9,
+        "name": "encrypted_refresh_token",
+        "type_info": "Bytea"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "31f6ff0cd80d38a5d9251eda7718e708407c87a43e25cbfbff6d5372a1ac950f"
+}

--- a/server/.sqlx/query-348012c7f55b1d5da62da4c64f9af049a3aee1e64fdf6cb619f127e688d18eb5.json
+++ b/server/.sqlx/query-348012c7f55b1d5da62da4c64f9af049a3aee1e64fdf6cb619f127e688d18eb5.json
@@ -1,0 +1,82 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT *\n            FROM GithubSponsors\n            WHERE user_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "github_sponsor_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "sponsor_type",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "github_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "github_login",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "sponsored_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_one_time_payment",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "privacy_level",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "amount_cents",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "tier_name",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "348012c7f55b1d5da62da4c64f9af049a3aee1e64fdf6cb619f127e688d18eb5"
+}

--- a/server/.sqlx/query-3c609569b32c21ff0d1eca2d734a297e6dc4162e19e7a0c730766af5fec49c8b.json
+++ b/server/.sqlx/query-3c609569b32c21ff0d1eca2d734a297e6dc4162e19e7a0c730766af5fec49c8b.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO GithubLinks (\n                github_link_id,\n                user_id,\n                external_github_id,\n                external_github_login,\n                encrypted_access_token,\n                encrypted_refresh_token,\n                access_token_expires_at,\n                refresh_token_expires_at\n            )\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)\n            RETURNING github_link_id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "github_link_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text",
+        "Text",
+        "Bytea",
+        "Bytea",
+        "Timestamptz",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "3c609569b32c21ff0d1eca2d734a297e6dc4162e19e7a0c730766af5fec49c8b"
+}

--- a/server/.sqlx/query-3e4f05be736b2a75a78f5c521964c605bf9ee58dbe8707239a10ca627992cd6e.json
+++ b/server/.sqlx/query-3e4f05be736b2a75a78f5c521964c605bf9ee58dbe8707239a10ca627992cd6e.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT YoutubeVideos.*\n        FROM YoutubeVideos\n        JOIN YoutubeVideoPlaylists using (youtube_video_id)\n        JOIN YoutubePlaylists using (youtube_playlist_id)\n        WHERE YoutubePlaylists.external_youtube_playlist_id = $1\n        ORDER BY published_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "youtube_video_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "external_youtube_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "published_at",
+        "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 5,
+        "name": "thumbnail_url",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "3e4f05be736b2a75a78f5c521964c605bf9ee58dbe8707239a10ca627992cd6e"
+}

--- a/server/.sqlx/query-50cafd5e9455b8fb069b3d3b42ceffb17a70cf580cbde006bc5fd14b1ab0419b.json
+++ b/server/.sqlx/query-50cafd5e9455b8fb069b3d3b42ceffb17a70cf580cbde006bc5fd14b1ab0419b.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE GithubLinks\n            SET\n                encrypted_access_token = $1,\n                encrypted_refresh_token = $2,\n                access_token_expires_at = $3,\n                refresh_token_expires_at = $4,\n                external_github_login = $5\n            WHERE github_link_id = $6\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea",
+        "Bytea",
+        "Timestamptz",
+        "Timestamptz",
+        "Text",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "50cafd5e9455b8fb069b3d3b42ceffb17a70cf580cbde006bc5fd14b1ab0419b"
+}

--- a/server/.sqlx/query-53b9fae322f4277e00c9ed49b33295cdca6163ada6556e602e7936811c1d682d.json
+++ b/server/.sqlx/query-53b9fae322f4277e00c9ed49b33295cdca6163ada6556e602e7936811c1d682d.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO LastRefreshAts (\n            key,\n            last_refresh_at\n        ) VALUES (\n            $1,\n            NOW()\n        ) ON CONFLICT (key) DO UPDATE SET\n            last_refresh_at = excluded.last_refresh_at\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "53b9fae322f4277e00c9ed49b33295cdca6163ada6556e602e7936811c1d682d"
+}

--- a/server/.sqlx/query-5d65767fbefb3a1b2e17da507e84bad7e343f9ef70ff799c1d1508e908dc03db.json
+++ b/server/.sqlx/query-5d65767fbefb3a1b2e17da507e84bad7e343f9ef70ff799c1d1508e908dc03db.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT YoutubePlaylists.external_youtube_playlist_id,\n        max(YoutubeVideos.published_at)\n        FROM YoutubeVideos\n        JOIN YoutubeVideoPlaylists using (youtube_video_id)\n        JOIN YoutubePlaylists using (youtube_playlist_id)\n        WHERE YoutubeVideos.published_at IS NOT NULL\n        GROUP BY YoutubePlaylists.external_youtube_playlist_id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "external_youtube_playlist_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "max",
+        "type_info": "Timestamp"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "5d65767fbefb3a1b2e17da507e84bad7e343f9ef70ff799c1d1508e908dc03db"
+}

--- a/server/.sqlx/query-5f60eb100e36748741e8f8729c7376bdf11e2c73551d0e1e4e700da27254adfb.json
+++ b/server/.sqlx/query-5f60eb100e36748741e8f8729c7376bdf11e2c73551d0e1e4e700da27254adfb.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM memory_blocks\n            WHERE memory_block_id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5f60eb100e36748741e8f8729c7376bdf11e2c73551d0e1e4e700da27254adfb"
+}

--- a/server/.sqlx/query-67277fe16e578605ce220d851dcbbf98ab20f7e20838aae83a4fd3677c72e999.json
+++ b/server/.sqlx/query-67277fe16e578605ce220d851dcbbf98ab20f7e20838aae83a4fd3677c72e999.json
@@ -1,0 +1,38 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO Sessions DEFAULT VALUES RETURNING *",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "session_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "67277fe16e578605ce220d851dcbbf98ab20f7e20838aae83a4fd3677c72e999"
+}

--- a/server/.sqlx/query-67d4e49bb4db0018519c78e18b8a222606da6d791ae9c4188a46d5f0347e28a1.json
+++ b/server/.sqlx/query-67d4e49bb4db0018519c78e18b8a222606da6d791ae9c4188a46d5f0347e28a1.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT thread_id FROM stitches WHERE stitch_id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "thread_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "67d4e49bb4db0018519c78e18b8a222606da6d791ae9c4188a46d5f0347e28a1"
+}

--- a/server/.sqlx/query-6a83f89200b8d3be71102cc194bee3845917cc19d819c290ecfcada182ff0c10.json
+++ b/server/.sqlx/query-6a83f89200b8d3be71102cc194bee3845917cc19d819c290ecfcada182ff0c10.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT *\n    FROM YoutubeVideos\n    WHERE youtube_video_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "youtube_video_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "external_youtube_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "published_at",
+        "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 5,
+        "name": "thumbnail_url",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "6a83f89200b8d3be71102cc194bee3845917cc19d819c290ecfcada182ff0c10"
+}

--- a/server/.sqlx/query-736b1555c3e89731b8daa19af927d7a904102871e9aa0f44d00eb4f483ec19d1.json
+++ b/server/.sqlx/query-736b1555c3e89731b8daa19af927d7a904102871e9aa0f44d00eb4f483ec19d1.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      INSERT INTO GithubLoginStates (github_login_state_id, app, state)\n      VALUES ($1, $2, 'created')\n      RETURNING *\n      ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "github_login_state_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "github_link_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "app",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "state",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "return_to",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "736b1555c3e89731b8daa19af927d7a904102871e9aa0f44d00eb4f483ec19d1"
+}

--- a/server/.sqlx/query-771cd4a8d0fc17b1cedc4cac45ccd38646345744bbd507798b463ee1a5db984e.json
+++ b/server/.sqlx/query-771cd4a8d0fc17b1cedc4cac45ccd38646345744bbd507798b463ee1a5db984e.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT player_github_username, sum(score), count(*)\n            FROM CookdWebhooks\n            WHERE player_github_username != 'anonymous'\n            GROUP BY player_github_username\n            ORDER BY sum(score) DESC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "player_github_username",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "sum",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      true,
+      null,
+      null
+    ]
+  },
+  "hash": "771cd4a8d0fc17b1cedc4cac45ccd38646345744bbd507798b463ee1a5db984e"
+}

--- a/server/.sqlx/query-789d311110f66954be5172b17228f3f6e8abcca5b536458b4a7b4e73c348e119.json
+++ b/server/.sqlx/query-789d311110f66954be5172b17228f3f6e8abcca5b536458b4a7b4e73c348e119.json
@@ -1,0 +1,82 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT *\n        FROM GithubSponsors\n        WHERE user_id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "github_sponsor_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "sponsor_type",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "github_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "github_login",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "sponsored_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_one_time_payment",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "privacy_level",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "amount_cents",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "tier_name",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "789d311110f66954be5172b17228f3f6e8abcca5b536458b4a7b4e73c348e119"
+}

--- a/server/.sqlx/query-7bbcb0798ecf0ac1fc6d67648b1be387c5d412ea9c19ebeb7932a315a4f51458.json
+++ b/server/.sqlx/query-7bbcb0798ecf0ac1fc6d67648b1be387c5d412ea9c19ebeb7932a315a4f51458.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT player_github_username, score\n            FROM CookdWebhooks\n            WHERE slug = $1 and subdomain = $2\n            ORDER BY score DESC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "player_github_username",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "score",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true,
+      false
+    ]
+  },
+  "hash": "7bbcb0798ecf0ac1fc6d67648b1be387c5d412ea9c19ebeb7932a315a4f51458"
+}

--- a/server/.sqlx/query-7c3a1e973a7c8f8b81b301db6ddf2b823307d3440af92562d9f606790fd651d9.json
+++ b/server/.sqlx/query-7c3a1e973a7c8f8b81b301db6ddf2b823307d3440af92562d9f606790fd651d9.json
@@ -1,0 +1,68 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT *\n            FROM Jobs\n            WHERE name = 'RefreshVideos'\n            ORDER BY created_at DESC\n            LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "job_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "payload",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 4,
+        "name": "run_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "locked_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "locked_by",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "context",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "7c3a1e973a7c8f8b81b301db6ddf2b823307d3440af92562d9f606790fd651d9"
+}

--- a/server/.sqlx/query-7d369511ad2315f55d34427de0f9793f912921c5039afb47caf962ad47470009.json
+++ b/server/.sqlx/query-7d369511ad2315f55d34427de0f9793f912921c5039afb47caf962ad47470009.json
@@ -1,0 +1,76 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n    SELECT *\n    FROM GoogleUsers\n    WHERE user_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "google_user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "external_google_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "external_google_email",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "encrypted_access_token",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 5,
+        "name": "access_token_expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "encrypted_refresh_token",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 7,
+        "name": "scope",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "7d369511ad2315f55d34427de0f9793f912921c5039afb47caf962ad47470009"
+}

--- a/server/.sqlx/query-8063184955d502f60c97be77d126f9665dba55d6fc49cbde8a6d0c63a756bd75.json
+++ b/server/.sqlx/query-8063184955d502f60c97be77d126f9665dba55d6fc49cbde8a6d0c63a756bd75.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n       SELECT state, Users.user_id\n       FROM GithubLoginStates\n       JOIN GithubLinks using (github_link_id)\n       JOIN Users using (user_id)\n       WHERE github_login_state_id = $1\n       ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "state",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "8063184955d502f60c97be77d126f9665dba55d6fc49cbde8a6d0c63a756bd75"
+}

--- a/server/.sqlx/query-811f09cf82fea8ef8d8944f102127e6cae8e8e910ba0c1687c5f862c94a44758.json
+++ b/server/.sqlx/query-811f09cf82fea8ef8d8944f102127e6cae8e8e910ba0c1687c5f862c94a44758.json
@@ -1,0 +1,44 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT cron_id, name, last_run_at, created_at, updated_at FROM Crons ORDER BY name",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "cron_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "last_run_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "811f09cf82fea8ef8d8944f102127e6cae8e8e910ba0c1687c5f862c94a44758"
+}

--- a/server/.sqlx/query-8c2565acb75e2a1d01ffea23b7c73c6e346ebdbae2e5a4abcda266cc7ddf8ab1.json
+++ b/server/.sqlx/query-8c2565acb75e2a1d01ffea23b7c73c6e346ebdbae2e5a4abcda266cc7ddf8ab1.json
@@ -1,0 +1,64 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM CookdWebhooks WHERE cookd_webhook_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "cookd_webhook_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "subdomain",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "slug",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "player_github_email",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "player_github_username",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "score",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "8c2565acb75e2a1d01ffea23b7c73c6e346ebdbae2e5a4abcda266cc7ddf8ab1"
+}

--- a/server/.sqlx/query-9010e57d7a37dee6ebcc7d3977f7fdcdbc254721ae26d2146732d334349115c9.json
+++ b/server/.sqlx/query-9010e57d7a37dee6ebcc7d3977f7fdcdbc254721ae26d2146732d334349115c9.json
@@ -1,0 +1,56 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM DiscordChannels",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "discord_channel_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "channel_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "channel_topic",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "channel_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "purpose",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "9010e57d7a37dee6ebcc7d3977f7fdcdbc254721ae26d2146732d334349115c9"
+}

--- a/server/.sqlx/query-90154daf417711a4624f41b387019d54e4efc1c24d0e5df72654d59afb498fd2.json
+++ b/server/.sqlx/query-90154daf417711a4624f41b387019d54e4efc1c24d0e5df72654d59afb498fd2.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT *\n      FROM YoutubeVideos\n      ORDER BY published_at DESC",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "youtube_video_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "external_youtube_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "published_at",
+        "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 5,
+        "name": "thumbnail_url",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "90154daf417711a4624f41b387019d54e4efc1c24d0e5df72654d59afb498fd2"
+}

--- a/server/.sqlx/query-91cbb48da130669505a720a25f5c82b53f522a9452de1fccc685c1c7547da3a0.json
+++ b/server/.sqlx/query-91cbb48da130669505a720a25f5c82b53f522a9452de1fccc685c1c7547da3a0.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO GoogleUsers (google_user_id, user_id, external_google_id, external_google_email, encrypted_access_token, access_token_expires_at, encrypted_refresh_token, scope)\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text",
+        "Text",
+        "Bytea",
+        "Timestamptz",
+        "Bytea",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "91cbb48da130669505a720a25f5c82b53f522a9452de1fccc685c1c7547da3a0"
+}

--- a/server/.sqlx/query-951b99d4eb188e21d107fe763987cc13cda5bfff65656a788d3d1de796ebba89.json
+++ b/server/.sqlx/query-951b99d4eb188e21d107fe763987cc13cda5bfff65656a788d3d1de796ebba89.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO YoutubePlaylists (\n                    youtube_playlist_id,\n                    external_youtube_playlist_id,\n                    title,\n                    description\n                ) VALUES (\n                    $1,\n                    $2,\n                    $3,\n                    $4\n                ) ON CONFLICT (external_youtube_playlist_id) DO UPDATE SET\n                    title = excluded.title,\n                    description = excluded.description\n                    RETURNING youtube_playlist_id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "youtube_playlist_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "951b99d4eb188e21d107fe763987cc13cda5bfff65656a788d3d1de796ebba89"
+}

--- a/server/.sqlx/query-98d649e87fd7bca48e7bdeefb686b3c7925ecfb4d91d0edf21a88058db7f1c20.json
+++ b/server/.sqlx/query-98d649e87fd7bca48e7bdeefb686b3c7925ecfb4d91d0edf21a88058db7f1c20.json
@@ -1,0 +1,76 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT * FROM GithubLinks WHERE github_link_id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "github_link_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "external_github_login",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "external_github_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "access_token_expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "refresh_token_expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "encrypted_access_token",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 9,
+        "name": "encrypted_refresh_token",
+        "type_info": "Bytea"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "98d649e87fd7bca48e7bdeefb686b3c7925ecfb4d91d0edf21a88058db7f1c20"
+}

--- a/server/.sqlx/query-9c0b557d8ff71a53dc16ea62d0d69fb903334651df72de1620f2e87e6fa9f14a.json
+++ b/server/.sqlx/query-9c0b557d8ff71a53dc16ea62d0d69fb903334651df72de1620f2e87e6fa9f14a.json
@@ -1,0 +1,57 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO YoutubeVideos (\n                youtube_video_id,\n                external_youtube_id,\n                title,\n                description,\n                published_at,\n                thumbnail_url\n            )\n            VALUES ($1, $2, $3, $4, $5, $6)\n            ON CONFLICT (external_youtube_id) DO UPDATE SET\n                title = $3,\n                description = $4,\n                published_at = $5,\n                thumbnail_url = $6\n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "youtube_video_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "external_youtube_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "published_at",
+        "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 5,
+        "name": "thumbnail_url",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Timestamp",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "9c0b557d8ff71a53dc16ea62d0d69fb903334651df72de1620f2e87e6fa9f14a"
+}

--- a/server/.sqlx/query-aac77a1dd333211a62b1a9b5716d3b9758c0598656b033b55a348ade5b3ab567.json
+++ b/server/.sqlx/query-aac77a1dd333211a62b1a9b5716d3b9758c0598656b033b55a348ade5b3ab567.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM CookdWebhooks WHERE subdomain = $1 AND slug = $2 ORDER BY score DESC",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "cookd_webhook_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "subdomain",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "slug",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "player_github_email",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "player_github_username",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "score",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "aac77a1dd333211a62b1a9b5716d3b9758c0598656b033b55a348ade5b3ab567"
+}

--- a/server/.sqlx/query-ae7671c4448bfdc1f97637e6b5b733285676eff7f6f2b099d5fc43b358af60d3.json
+++ b/server/.sqlx/query-ae7671c4448bfdc1f97637e6b5b733285676eff7f6f2b099d5fc43b358af60d3.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO memory_blocks (block_type, content)\n            VALUES ($1, $2)\n            RETURNING \n                memory_block_id,\n                block_type as \"block_type: MemoryBlockType\",\n                content,\n                created_at,\n                updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "memory_block_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "block_type: MemoryBlockType",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "content",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "ae7671c4448bfdc1f97637e6b5b733285676eff7f6f2b099d5fc43b358af60d3"
+}

--- a/server/.sqlx/query-aee733309c85b5ce956583342603188a831d9e8d887d3d55753a5040cca1a399.json
+++ b/server/.sqlx/query-aee733309c85b5ce956583342603188a831d9e8d887d3d55753a5040cca1a399.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT *\n        FROM Users\n        WHERE user_id = $1 and user_id is not null\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "aee733309c85b5ce956583342603188a831d9e8d887d3d55753a5040cca1a399"
+}

--- a/server/.sqlx/query-af0bcc201d27b5f7ee80d5469a23d1a5417c78c478559cb0ab2fb5f5796484a0.json
+++ b/server/.sqlx/query-af0bcc201d27b5f7ee80d5469a23d1a5417c78c478559cb0ab2fb5f5796484a0.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO Users (user_id)\n            VALUES ($1)\n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "af0bcc201d27b5f7ee80d5469a23d1a5417c78c478559cb0ab2fb5f5796484a0"
+}

--- a/server/.sqlx/query-b06c4182cbcfc724c2fe44341b7704780b5b227609ddd0cb66ebcd31c0d31004.json
+++ b/server/.sqlx/query-b06c4182cbcfc724c2fe44341b7704780b5b227609ddd0cb66ebcd31c0d31004.json
@@ -1,0 +1,77 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT *\n            FROM GithubLinks\n            WHERE user_id = $1 AND external_github_id = $2\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "github_link_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "external_github_login",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "external_github_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "access_token_expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "refresh_token_expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "encrypted_access_token",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 9,
+        "name": "encrypted_refresh_token",
+        "type_info": "Bytea"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b06c4182cbcfc724c2fe44341b7704780b5b227609ddd0cb66ebcd31c0d31004"
+}

--- a/server/.sqlx/query-b0a656837da59e32825b9d7a9585104051560f85be7ed446517d792ebef9dbf3.json
+++ b/server/.sqlx/query-b0a656837da59e32825b9d7a9585104051560f85be7ed446517d792ebef9dbf3.json
@@ -1,0 +1,54 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE GithubLoginStates\n        SET state = $1, github_link_id = $2\n        WHERE github_login_state_id = $3 AND state = 'created'\n        RETURNING *\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "github_login_state_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "github_link_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "app",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "state",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "return_to",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "b0a656837da59e32825b9d7a9585104051560f85be7ed446517d792ebef9dbf3"
+}

--- a/server/.sqlx/query-b49e4c1a92b9685a6c1a68fe33e1a7ba2e90f3ece283bc7e9249e7323c856d6c.json
+++ b/server/.sqlx/query-b49e4c1a92b9685a6c1a68fe33e1a7ba2e90f3ece283bc7e9249e7323c856d6c.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE GithubSponsors SET is_active = false\n        WHERE github_id not in (Select * from UNNEST($1::text[]))\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b49e4c1a92b9685a6c1a68fe33e1a7ba2e90f3ece283bc7e9249e7323c856d6c"
+}

--- a/server/.sqlx/query-b6f5c5508b22561d17f2d7b71404985e90a9b0be9c6d67bbbc48d031d2e2ad95.json
+++ b/server/.sqlx/query-b6f5c5508b22561d17f2d7b71404985e90a9b0be9c6d67bbbc48d031d2e2ad95.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n       UPDATE GithubLoginStates\n       SET state = 'claimed'\n       WHERE github_login_state_id = $1\n       RETURNING *\n       ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "github_login_state_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "github_link_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "app",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "state",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "return_to",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "b6f5c5508b22561d17f2d7b71404985e90a9b0be9c6d67bbbc48d031d2e2ad95"
+}

--- a/server/.sqlx/query-b79ff3e31d2a3dd71b71cf74cf5e6824f8aa64dddf9b3ea78f511982ce2343cb.json
+++ b/server/.sqlx/query-b79ff3e31d2a3dd71b71cf74cf5e6824f8aa64dddf9b3ea78f511982ce2343cb.json
@@ -1,0 +1,54 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n      INSERT INTO GithubLoginStates (github_login_state_id, state, return_to)\n      VALUES ($1, $2, $3)\n      RETURNING *\n      ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "github_login_state_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "github_link_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "app",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "state",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "return_to",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "b79ff3e31d2a3dd71b71cf74cf5e6824f8aa64dddf9b3ea78f511982ce2343cb"
+}

--- a/server/.sqlx/query-b88aff512f5bc64704b9e36470bd41486e767319d2fc35a4a1fe239925b103ab.json
+++ b/server/.sqlx/query-b88aff512f5bc64704b9e36470bd41486e767319d2fc35a4a1fe239925b103ab.json
@@ -1,0 +1,82 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n          SELECT *\n          FROM GithubSponsors\n          WHERE user_id = $1\n          ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "github_sponsor_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "sponsor_type",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "github_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "github_login",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "sponsored_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_one_time_payment",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "privacy_level",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "amount_cents",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "tier_name",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "b88aff512f5bc64704b9e36470bd41486e767319d2fc35a4a1fe239925b103ab"
+}

--- a/server/.sqlx/query-bcf7e9adb84a9a0bbab34ef6ee4e8e90795970881c893b7f8c9c4623b835b736.json
+++ b/server/.sqlx/query-bcf7e9adb84a9a0bbab34ef6ee4e8e90795970881c893b7f8c9c4623b835b736.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM Sessions where session_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "session_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "bcf7e9adb84a9a0bbab34ef6ee4e8e90795970881c893b7f8c9c4623b835b736"
+}

--- a/server/.sqlx/query-be26648e023c218ab11fb702e45a2cd2c89e6fb1dfbb8f4343c6ef6ac548f882.json
+++ b/server/.sqlx/query-be26648e023c218ab11fb702e45a2cd2c89e6fb1dfbb8f4343c6ef6ac548f882.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT *\n        FROM YoutubeVideos\n        ORDER BY published_at DESC LIMIT 3",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "youtube_video_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "external_youtube_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "title",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "published_at",
+        "type_info": "Timestamp"
+      },
+      {
+        "ordinal": 5,
+        "name": "thumbnail_url",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "be26648e023c218ab11fb702e45a2cd2c89e6fb1dfbb8f4343c6ef6ac548f882"
+}

--- a/server/.sqlx/query-bf7e21d8a02f971e7bdc5c771399006e844797c1dc6eba86041367dd98eab267.json
+++ b/server/.sqlx/query-bf7e21d8a02f971e7bdc5c771399006e844797c1dc6eba86041367dd98eab267.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM LastRefreshAts",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "key",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "last_refresh_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "bf7e21d8a02f971e7bdc5c771399006e844797c1dc6eba86041367dd98eab267"
+}

--- a/server/.sqlx/query-c2c6cf06b96a390c1a22d813ceaf55fb7722b072b46f1fe9a10605bd82b614f2.json
+++ b/server/.sqlx/query-c2c6cf06b96a390c1a22d813ceaf55fb7722b072b46f1fe9a10605bd82b614f2.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT \n                memory_block_id,\n                block_type as \"block_type: MemoryBlockType\",\n                content,\n                created_at,\n                updated_at\n            FROM memory_blocks\n            WHERE block_type = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "memory_block_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "block_type: MemoryBlockType",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "content",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c2c6cf06b96a390c1a22d813ceaf55fb7722b072b46f1fe9a10605bd82b614f2"
+}

--- a/server/.sqlx/query-c3d376801ba872893daf5326d975a0a14c5b3a6d5ac4de3fd79be617d4725e89.json
+++ b/server/.sqlx/query-c3d376801ba872893daf5326d975a0a14c5b3a6d5ac4de3fd79be617d4725e89.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n    INSERT INTO YoutubeVideoPlaylists (\n        youtube_video_playlist_id,\n        youtube_playlist_id,\n        youtube_video_id\n    ) VALUES (\n        $1,\n        $2,\n        $3\n    ) ON CONFLICT (youtube_playlist_id, youtube_video_id) DO NOTHING",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "c3d376801ba872893daf5326d975a0a14c5b3a6d5ac4de3fd79be617d4725e89"
+}

--- a/server/.sqlx/query-cf3fd2ea8c2693172d2eb22f5d96111a2e644bcc0f602468098c56755b5ba723.json
+++ b/server/.sqlx/query-cf3fd2ea8c2693172d2eb22f5d96111a2e644bcc0f602468098c56755b5ba723.json
@@ -1,0 +1,76 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT *\n            FROM GithubLinks\n            WHERE user_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "github_link_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "external_github_login",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "external_github_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "access_token_expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "refresh_token_expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "encrypted_access_token",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 9,
+        "name": "encrypted_refresh_token",
+        "type_info": "Bytea"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "cf3fd2ea8c2693172d2eb22f5d96111a2e644bcc0f602468098c56755b5ba723"
+}

--- a/server/.sqlx/query-d57c4f1251ed7c0136ee7ac5f05fa2de107b9f6f6257370d1e206e8b471071f0.json
+++ b/server/.sqlx/query-d57c4f1251ed7c0136ee7ac5f05fa2de107b9f6f6257370d1e206e8b471071f0.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n    UPDATE GoogleUsers\n    SET\n        encrypted_access_token = $1,\n        access_token_expires_at = NOW() + (INTERVAL '1 second' * $3)\n    WHERE google_user_id = $2\n    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Bytea",
+        "Uuid",
+        "Float8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d57c4f1251ed7c0136ee7ac5f05fa2de107b9f6f6257370d1e206e8b471071f0"
+}

--- a/server/.sqlx/query-dcc086875437f897e45115b9c5ee8276d983f6bc6cb55d76602ef30f7171fd3a.json
+++ b/server/.sqlx/query-dcc086875437f897e45115b9c5ee8276d983f6bc6cb55d76602ef30f7171fd3a.json
@@ -1,0 +1,27 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO CookdWebhooks (subdomain, slug, player_github_username, score, created_at, updated_at)\n        VALUES ($1, $2, $3, $4, $5, $6) RETURNING cookd_webhook_id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "cookd_webhook_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Int4",
+        "Timestamptz",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "dcc086875437f897e45115b9c5ee8276d983f6bc6cb55d76602ef30f7171fd3a"
+}

--- a/server/.sqlx/query-e45ebd4a51e63e57fbb0f43330cbf3eba29b962ac90c2cfd2d2e00b12dfdd67e.json
+++ b/server/.sqlx/query-e45ebd4a51e63e57fbb0f43330cbf3eba29b962ac90c2cfd2d2e00b12dfdd67e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE Crons SET last_run_at = $1, updated_at = NOW() WHERE cron_id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e45ebd4a51e63e57fbb0f43330cbf3eba29b962ac90c2cfd2d2e00b12dfdd67e"
+}

--- a/server/.sqlx/query-ead88f08471296da5bcfd6d48870275d59ccb383fe4ea0ff5ef0f841f1d91c5b.json
+++ b/server/.sqlx/query-ead88f08471296da5bcfd6d48870275d59ccb383fe4ea0ff5ef0f841f1d91c5b.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE memory_blocks\n            SET content = $1, updated_at = NOW()\n            WHERE memory_block_id = $2\n            RETURNING \n                memory_block_id,\n                block_type as \"block_type: MemoryBlockType\",\n                content,\n                created_at,\n                updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "memory_block_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "block_type: MemoryBlockType",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "content",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "ead88f08471296da5bcfd6d48870275d59ccb383fe4ea0ff5ef0f841f1d91c5b"
+}

--- a/server/.sqlx/query-f16f39d0b272668a55c8bdc133719adab1ad0aec0f30086052dbb18a1fe5025f.json
+++ b/server/.sqlx/query-f16f39d0b272668a55c8bdc133719adab1ad0aec0f30086052dbb18a1fe5025f.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE DiscordChannels SET channel_name = $1, channel_topic = $2 WHERE channel_id = $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f16f39d0b272668a55c8bdc133719adab1ad0aec0f30086052dbb18a1fe5025f"
+}

--- a/server/.sqlx/query-f2660608e21f7606a8ecc2cc16f825a156042c477c11f933133d0bd7c22c04c4.json
+++ b/server/.sqlx/query-f2660608e21f7606a8ecc2cc16f825a156042c477c11f933133d0bd7c22c04c4.json
@@ -1,0 +1,38 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            google_user_id,\n            encrypted_access_token,\n            encrypted_refresh_token,\n            access_token_expires_at\n        FROM GoogleUsers\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "google_user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "encrypted_access_token",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 2,
+        "name": "encrypted_refresh_token",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 3,
+        "name": "access_token_expires_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "f2660608e21f7606a8ecc2cc16f825a156042c477c11f933133d0bd7c22c04c4"
+}

--- a/server/.sqlx/query-f6c5bc93c1c4b697eb7a9e752686f5e72038d3047671d53d33c9a6826f38c2ac.json
+++ b/server/.sqlx/query-f6c5bc93c1c4b697eb7a9e752686f5e72038d3047671d53d33c9a6826f38c2ac.json
@@ -1,0 +1,56 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM DiscordChannels WHERE purpose = 'byte_submissions'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "discord_channel_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "channel_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "channel_topic",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "channel_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "purpose",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "f6c5bc93c1c4b697eb7a9e752686f5e72038d3047671d53d33c9a6826f38c2ac"
+}

--- a/server/.sqlx/query-fc63bca08783c85b69c7788ea0804ab0fa9eef9d1ffae95d784cfa8f71ca0f0e.json
+++ b/server/.sqlx/query-fc63bca08783c85b69c7788ea0804ab0fa9eef9d1ffae95d784cfa8f71ca0f0e.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT Users.*, GithubLinks.github_link_id\n        FROM Users\n        JOIN GithubLinks USING (user_id)\n        WHERE GithubLinks.external_github_id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "github_link_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "fc63bca08783c85b69c7788ea0804ab0fa9eef9d1ffae95d784cfa8f71ca0f0e"
+}

--- a/server/.sqlx/query-ffd467e5faa247288b63f7e47c07fb1385fce04eca0993ba06f6a42e461a1340.json
+++ b/server/.sqlx/query-ffd467e5faa247288b63f7e47c07fb1385fce04eca0993ba06f6a42e461a1340.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT \n                memory_block_id,\n                block_type as \"block_type: MemoryBlockType\",\n                content,\n                created_at,\n                updated_at\n            FROM memory_blocks\n            WHERE memory_block_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "memory_block_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "block_type: MemoryBlockType",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "content",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "ffd467e5faa247288b63f7e47c07fb1385fce04eca0993ba06f6a42e461a1340"
+}

--- a/server/src/al/standup.rs
+++ b/server/src/al/standup.rs
@@ -17,6 +17,8 @@ pub struct AnthropicTool {
 pub struct AnthropicRequest {
     pub model: String,
     pub max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system: Option<String>,
     pub messages: Vec<Message>,
     pub tools: Vec<AnthropicTool>,
     pub tool_choice: Option<ToolChoice>,

--- a/server/src/http_server/api/threads.rs
+++ b/server/src/http_server/api/threads.rs
@@ -275,25 +275,13 @@ mod tests {
         let first_stitch = &stitches[0];
         assert_eq!(
             first_stitch.stitch_type,
-            db::agentic_threads::StitchType::InitialPrompt
+            db::agentic_threads::StitchType::SystemPrompt
         );
         assert!(first_stitch.previous_stitch_id.is_none());
 
-        // Verify the stitch contains a system message
+        // Verify the stitch contains the system prompt text
         let request = first_stitch.llm_request.as_ref().unwrap();
-        let messages = request.get("messages").unwrap().as_array().unwrap();
-        assert_eq!(messages.len(), 1);
-
-        let message = &messages[0];
-        assert_eq!(message.get("role").unwrap().as_str().unwrap(), "system");
-
-        let content = message.get("content").unwrap().as_array().unwrap();
-        assert_eq!(content.len(), 1);
-
-        let text_content = &content[0];
-        assert_eq!(text_content.get("type").unwrap().as_str().unwrap(), "text");
-
-        let text = text_content.get("text").unwrap().as_str().unwrap();
+        let text = request.get("text").unwrap().as_str().unwrap();
         assert!(text.contains("AI assistant")); // From base instructions
     }
 }


### PR DESCRIPTION
- Add SystemPrompt variant to StitchType enum  
- Create migration to update stitch_type check constraint
- Add system field to AnthropicRequest struct
- Update create_system_prompt to use new SystemPrompt stitch type
- Add extract_system_prompt function to get system prompts separately
- Update reconstruct_messages to skip SystemPrompt stitches
- Update process_single_step to extract and pass system prompts
- Update tests to handle new system prompt behavior

This separates system prompts from the messages array to comply with Anthropic API requirements where system prompts must be a top-level field.